### PR TITLE
Non-ANSI chars in zipped filenames

### DIFF
--- a/Components/MHLComponents/unit_MHLArchiveHelpers.pas
+++ b/Components/MHLComponents/unit_MHLArchiveHelpers.pas
@@ -168,7 +168,7 @@ begin
 
   for i := 0 to High(FZip.FileInfos) do
   begin
-    FN := TEncoding.UTF8.GetString(FZip.FileInfos[i].FileName);
+    FN := FZip.FileNames[i];
     case Mode of
       smFull: begin
                 if FN = AFileName then
@@ -214,7 +214,7 @@ begin
   Result := -1;
   for i := 0 to High(FZip.FileInfos) do
   begin
-    FN := TEncoding.UTF8.GetString(FZip.FileInfos[i].FileName);
+    FN := FZip.FileNames[i];
     if ExtractFileExt(FN) = Ext then
     begin
       Result := FZip.GetFileIndex(FN);
@@ -225,7 +225,7 @@ end;
 
 function TMHLZip.GetLastName: string;
 begin
-  Result := TEncoding.UTF8.GetString(FZip.FileInfos[FLastID].FileName);
+  Result := FZip.FileNames[FLastID];
 end;
 
 function TMHLZip.GetLastSize: Integer;


### PR DESCRIPTION
UTF8 conversion not needed. We already have FileNames array of strings.