### PR TITLE
Give MHLMcpServer the VCL unit scopes its shared units need

### DIFF
--- a/Utils/MHLMcpServer/MHLMcpServer.dproj
+++ b/Utils/MHLMcpServer/MHLMcpServer.dproj
@@ -38,7 +38,7 @@
         <SanitizedProjectName>MHLMcpServer</SanitizedProjectName>
         <DCC_DependencyCheckOutputName>MHLMcpServer.exe</DCC_DependencyCheckOutputName>
         <DCC_UnitSearchPath>..\..\Program\Units;..\..\Program\DAO;..\..\Program\DAO\SQLite;..\..\Program\DAO\SQLite\Lib;..\..\Program\DataModules;..\..\Program\UtilsImpl;..\..\Components\MHLComponents;..\..\Components\MHLComponents\Units;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
-        <DCC_Namespace>System;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;Bde;Xml.Win;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;$(DCC_Namespace)</DCC_Namespace>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=MyHomeLib;FileDescription=MyHomeLib MCP Server;FileVersion=1.0.0.0;InternalName=MHLMcpServer;LegalCopyright=;LegalTrademarks=;OriginalFilename=MHLMcpServer.exe;ProductName=MyHomeLib;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>


### PR DESCRIPTION
The group build fails at `F2613 Unit 'ImgList' not found` when building
`MHLMcpServer.dproj`.

`dm_user.pas` — shared with the main application — uses the legacy aliases
`ImgList`, `Controls` and `ComObj`, which resolve only when `Vcl`, `Winapi`
and `System.Win` are in the unit scope list. `MyhomeLib.dproj` has carried
that list all along; `MHLMcpServer.dproj` had only `System`, so it could not
compile the application units it shares.

This mirrors MyhomeLib's scopes onto the MCP server project. One line.

## Why it surfaced now

It has been latent for a while and was masked by uncommitted working-tree
changes to `MHLMcpServer.dproj` on the maintainer's machine. A clean checkout
of `master` does not build the group.

## Verification

- Win32 group build clean from `origin/master` + this commit — every project
  compiles and links.
- `Utils/MHLMcpServer/tests/extract_tests.js` — 10/10, no failures.

The Win64 group build additionally reports `F2039 Could not create output
file 'MHLMcpServer.exe'` whenever an MHLMcpServer process is running; that is
the exe being locked, not a code error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)